### PR TITLE
Add missing header.

### DIFF
--- a/xilinx/pins.cc
+++ b/xilinx/pins.cc
@@ -17,6 +17,8 @@
  *
  */
 
+#include <set>
+
 #include "nextpnr.h"
 
 NEXTPNR_NAMESPACE_BEGIN


### PR DESCRIPTION
Compiling on Manjaro with gcc 12.2.1 reported the missing header.